### PR TITLE
Support adding routes to kernel routing table with additional argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,8 @@ binit_net_if=<if>
   Specify on which interface the network should be configured. Optionally a vlan can be specified separated by a dot. Example: eth0 or eth0.55
 binit_net_addr=<addr/cidr>
   Configure <addr> with <cidr> netmask on binit_net_if. Usualy you want something like '1.2.3.4/24'. If you will not add /CIDR, the IP will be configured with /32 thus you will be not able to connect to it unless you specify binit_net_gw.
+binit_net_route=<addr/cidr>
+  Optional static on-link route(s) to add (can be given multiple times).
 binit_net_gw=<addr>
   Optional gateway config, if you want to connect via WAN.
 rw

--- a/sourceroot/functions.sh
+++ b/sourceroot/functions.sh
@@ -181,6 +181,9 @@ process_commandline_options() {
 			binit_net_addr\=*)
 				binit_net_addr=$(get_opt $i)
 			;;
+			binit_net_route\=*)
+				binit_net_routes="${binit_net_routes} $(get_opt $i)"
+			;;
 			binit_net_gw\=*)
 				binit_net_gw=$(get_opt $i)
 			;;
@@ -413,8 +416,16 @@ SetupNetwork() {
 
 	einfo "Bringing up ${binit_net_if} interface ..."
 	run ip link set up dev "${binit_net_if}"
+
 	einfo "Setting ${binit_net_addr} on ${binit_net_if} ..."
 	run ip addr add "${binit_net_addr}" dev "${binit_net_if}"
+
+	if [ -n "${binit_net_routes}" ]; then
+		einfo "Adding routes${binit_net_routes}"
+		for route in ${binit_net_routes} ; do
+			run ip route add "${route}" dev "${binit_net_if}"
+		done
+	fi
 
 	if [ -n "${binit_net_gw}" ]; then
 		einfo "Setting default routing via '${binit_net_gw}' ..."


### PR DESCRIPTION
Sometimes, especially with virtual server hosting providers, or when
IPv6 is involved, your gateway will be outside of your assigned prefix,
and adding a wider on-link route by decreasing the prefix length on your
IP address assignment is not the correct way to go about bringing it
back "into" your addressible nodes.

For example, if your gateway is 203.0.113.1, but your IP address space
is 203.0.113.192/28, then your gateway is not inside your assignment and
adding a route to the gateway will fail. However, if you specify
binit_net_addr=203.0.113.193/24, instead of /28, this appears to solve
the problem; you can communicate with your gateway because it is now
encompassed by an on-link route, and so you can add a default route via
it.

However, this has the unwanted side-effect of making all other addresses
within the larger network appear to be "on-link" to the kernel, meaning
you will be unable to communicate with them if this is not the case.

The most extreme case of this that I have seen is someone adding their
IP address as binit_net_addr=a.b.c.d/8 when they only have e.g. a /28
prefix. This will be catastrophic if they need to log in to the
initramfs from a remote location (e.g. to unlock a LUKS volume) and
their remote IP address starts with the same first octet, because the
kernel will believe it is on the same link (after all, an on-link route
for that prefix exists), and it will therefore not use the gateway!

This patch introduces a new "binit_net_route" option (which can be given
multiple times on the command line, each with a different route). It
accumulates all of the routes it is given and adds them before adding
the (default) gateway route (binit_net_gw).

Now, instead of specifying:

binit_net_if=eth0
binit_net_addr=203.0.113.193/24         # Bring the gateway into "scope"
binit_net_gw=203.0.113.1

You can instead do:

binit_net_if=eth0
binit_net_addr=203.0.113.193/28         # Use the correct prefix size
binit_net_route=203.0.113.1/32          # Makes gateway usable
binit_net_gw=203.0.113.1

And adding the gateway route will still work (because you have an on-
link route for the gateway).

Because this option can be repeated, it will also allow you to add any
other static on-link routes that you might like, though no other usecase
comes immediately to mind (I can imagine plenty of use cases for adding
additional static non-default gateway routes, but this patch will not
process those options, as they by necessity must have a space character
in them to specify a gateway for the given prefix).