### PR TITLE
Do not die with RAID

### DIFF
--- a/sourceroot/functions.sh
+++ b/sourceroot/functions.sh
@@ -118,8 +118,8 @@ populate_dev_disk_by_label_and_uuid() {
 		vars="${blkid_output#*:}"
 		eval "${vars}"
 
-		[ "${LABEL}" ] && run ln -s "../../${block_device}" "/dev/disk/by-label/${LABEL}"
-		[ "${UUID}" ] && run ln -s "../../${block_device}" "/dev/disk/by-uuid/${UUID}"
+		[ "${LABEL}" ] && run ln -sf "../../${block_device}" "/dev/disk/by-label/${LABEL}"
+		[ "${UUID}" ] && run ln -sf "../../${block_device}" "/dev/disk/by-uuid/${UUID}"
 	done
 }
 


### PR DESCRIPTION
The UUIDs of disks in particular RAID setups are the same. So, we need
this symlinking to carry the -f so that we don't get a fatal error.

Signed-off-by: Jason A. Donenfeld <Jason@zx2c4.com>