### PR TITLE
Ipv4ll self assigned ip address support

### DIFF
--- a/sourceroot/bin/autoip-query
+++ b/sourceroot/bin/autoip-query
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# A simple plug for zcap for better-initramfs.
+# Does what dhcp-query would do if dhcp-query fails
+  
+exec > /dhcp-query-result
+
+case "$1" in
+    config)
+        printf 'binit_net_addr=%s\n' "${ip}"
+    ;;  
+esac

--- a/sourceroot/functions.sh
+++ b/sourceroot/functions.sh
@@ -379,8 +379,8 @@ SetupNetwork() {
 
 	if [ "${binit_net_addr}" =  'dhcp' ]; then
 		einfo "Using DHCP on ${binit_net_if} ..."
-		run udhcpc -i "${binit_net_if}" -s /bin/dhcp-query -q -f
-		. /dhcp-query-result
+		udhcpc -i "${binit_net_if}" -s /bin/dhcp-query -q -f -t 6 -n || run zcip -q "${binit_net_if}" -f -v  /bin/autoip-query
+		run . /dhcp-query-result
 	fi
 
 	einfo "Setting ${binit_net_addr} on ${binit_net_if} ..."


### PR DESCRIPTION
I added this because I had to unlock a server using just a crossover cable recently.