### PR TITLE
Disabled port forwarding by dropbear

### DIFF
--- a/sourceroot/functions.sh
+++ b/sourceroot/functions.sh
@@ -426,7 +426,7 @@ setup_sshd() {
 	fi
 
 	einfo 'Starting dropbear sshd ...'
-	run dropbear -s -p "${binit_net_addr%/*}:${sshd_port:-22}"
+	run dropbear -j -k -s -p "${binit_net_addr%/*}:${sshd_port:-22}"
 }
 
 wait_sshd() {


### PR DESCRIPTION
Without this, users are able to open tunnels to arbitrary hosts (using -L and -g flags from ssh).
This could be used to probe the local network, or set up a proxy.

This is a potential security issue.